### PR TITLE
Continuous integration for pyephem on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,20 @@
 language: python
 
 python:
-#  - "2.5"
-#  - "2.6"
+  - "2.5"
+  - "2.6"
   - "2.7"
-  - "3.2"
+  # Python 3
+#  - "3.2"
 
 # command to install dependencies
 install:
   - python setup.py install
+  # To run tests on Python 2.5 and 2.6 we need the unittest2 module
+  - pip install -q unittest2 --use-mirrors
 
 # command to run tests
 script:
   - cd src/ephem/tests/
-  - python -m unittest discover
+  # - python -m unittest discover
+  - unit2 discover ephem


### PR DESCRIPTION
I'm haven't looked why the tests are failing for Python 2.5 and 2.6, I think I put the command that was given in the INSTALL.
