### PR TITLE
Really use J2000 as default epoch for Coordinate objects

### DIFF
--- a/ephem/__init__.py
+++ b/ephem/__init__.py
@@ -563,7 +563,7 @@ class Coordinate(object):
         elif len(args) == 2:
             self.set(*args)
             if epoch is None:
-                self.epoch = epoch = Date('2000')
+                self.epoch = epoch = Date(J2000)
 
         else:
             raise TypeError(


### PR DESCRIPTION
PyEphem documentation says:

> When creating a coordinate, you can optionally pass an epoch= keyword specifying the epoch for the coordinate system. Otherwise the epoch is copied from the body or other coordinate being used, or J2000 is used as the default.

but the statement about J2000 being the default turns out not to be entirely true, as can be demonstrated with the following test:

```
>>> import ephem
>>> print(ephem.Equatorial(0, 0).epoch)
2000/1/1 00:00:00
>>> print(ephem.Equatorial(0, 0, epoch=ephem.J2000).epoch)
2000/1/1 12:00:00
```

Note that in fact, the default epoch date differs from J2000 by 12 hours.

The proposed patch fixes this discrepancy.
