### PR TITLE
Optionally import setuptools for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 import os
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+from distutils.core import Extension
 from glob import glob
 
 # Read the current version from ephem/__init__.py itself.


### PR DESCRIPTION
This changes setup.py to use setuptool's version of setup if it is there, as it makes making wheels for windows possible.  It will fallback to distutils if setuptools is not available.