### PR TITLE
Update canonical package name to match readme.

### DIFF
--- a/ephem/doc/index.rst
+++ b/ephem/doc/index.rst
@@ -160,7 +160,7 @@ is to use the pip_ command, like this:
 .. _pip: http://pypi.python.org/pypi/pip
 .. code-block:: bash
 
-   $ pip install pyephem
+   $ pip install ephem
 
 Better yet,
 you can use virtualenv_ to create a virtual environment,

--- a/ephem/doc/index.rst
+++ b/ephem/doc/index.rst
@@ -174,7 +174,7 @@ you should visit the `PyEphem entry`_
 at the Python Package Index,
 or use the links at the top of this page.
 
-.. _PyEphem entry: http://pypi.python.org/pypi/pyephem/
+.. _PyEphem entry: http://pypi.python.org/pypi/ephem/
 .. _virtualenv: http://pypi.python.org/pypi/virtualenv
 
 Documentation


### PR DESCRIPTION
I believe the preferred name for the package is pyephem. This PR clarifies that preference.