### PR TITLE
using Python 3 print() function in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,10 +43,11 @@ are represented by Python objects,
 while dates and angles automatically print themselves
 in standard astronomical formats::
 
+ >>> from __future__ import print_function
  >>> import ephem
  >>> mars = ephem.Mars()
  >>> mars.compute('2008/1/1')
- >>> print mars.ra, mars.dec
+ >>> print(mars.ra, mars.dec)
  5:59:27.35 26:56:27.4
 
 The documentation includes both a `Quick Reference`_ and a `Tutorial`_,

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,13 @@ are represented by Python objects,
 while dates and angles automatically print themselves
 in standard astronomical formats::
 
- >>> from __future__ import print_function
  >>> import ephem
  >>> mars = ephem.Mars()
  >>> mars.compute('2008/1/1')
- >>> print(mars.ra, mars.dec)
- 5:59:27.35 26:56:27.4
+ >>> print(mars.ra)
+ 5:59:27.35
+ >>> print(mars.dec)
+ 26:56:27.4
 
 The documentation includes both a `Quick Reference`_ and a `Tutorial`_,
 which are included in text files within the module itself


### PR DESCRIPTION
Since the lib supports Python 3, maybe use that as example in README.

Please note that needed to add the `__future__` import so that in Py2, it will not print a tuple.