### PR TITLE
Tests: datetime is imported from datetime module, so don't refer to module

### DIFF
--- a/ephem/doc/date.rst
+++ b/ephem/doc/date.rst
@@ -135,10 +135,10 @@ Datetime objects
   will give unexpected results.
   Instead, use the ``datetime.utcnow()`` constructor:
 
-    >>> d = datetime.datetime.utcnow()
+    >>> d = datetime.utcnow()
     >>> ephem.Date(d)
     2015/12/14 15:42:14
-    >>> d = datetime.datetime.utcfromtimestamp(1450107734)
+    >>> d = datetime.utcfromtimestamp(1450107734)
     >>> ephem.Date(d)
     2015/12/14 15:42:14
 
@@ -199,7 +199,7 @@ Calculating with dates
 PyEphem dates are encoded as the “Dublin Julian Day”,
 which is the number of days (including any fraction)
 that have passed since the last day of 1899, at noon.
-From there, increasing the value by one moves to the next day: 
+From there, increasing the value by one moves to the next day:
 
     >>> print(ephem.Date(0))
     1899/12/31 12:00:00


### PR DESCRIPTION
The build is failing like this:
```
======================================================================
FAIL: /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst
Doctest: date.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/python/2.7.9/lib/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for date.rst
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst", line 0

----------------------------------------------------------------------
File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst", line 138, in date.rst
Failed example:
    d = datetime.datetime.utcnow()
Exception raised:
    Traceback (most recent call last):
      File "/opt/python/2.7.9/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest date.rst[18]>", line 1, in <module>
        d = datetime.datetime.utcnow()
    AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
----------------------------------------------------------------------
File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst", line 139, in date.rst
Failed example:
    ephem.Date(d)
Expected:
    2015/12/14 15:42:14
Got:
    36884.028657407405
----------------------------------------------------------------------
File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst", line 141, in date.rst
Failed example:
    d = datetime.datetime.utcfromtimestamp(1450107734)
Exception raised:
    Traceback (most recent call last):
      File "/opt/python/2.7.9/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest date.rst[20]>", line 1, in <module>
        d = datetime.datetime.utcfromtimestamp(1450107734)
    AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
----------------------------------------------------------------------
File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/ephem/tests/../doc/date.rst", line 142, in date.rst
Failed example:
    ephem.Date(d)
Expected:
    2015/12/14 15:42:14
Got:
    36884.028657407405
```

Two of the four problems are because `datetime` is imported from the module `datetime` like this: `from datetime import date, datetime`, and then the module is referred to: `datetime.datetime.utcnow()`. In this case, it's only needed to refer to `datetime.utcnow()`.

---

I'm not sure what's causing the other two problems, I see `ephem.Date` is really `_libastro.Date`, and I get the expected values like `2015/12/14 15:42:14` when briefly trying it locally.

Anyway, here's a fix for two of the four.
