### PR TITLE
Define correct preprocessor symbol in dtoa.c according to byte order

### DIFF
--- a/extensions/dtoa.c
+++ b/extensions/dtoa.c
@@ -62,7 +62,13 @@
  *		for 0 <= k <= 22).
  */
 
+#if defined(__s390__) || defined(__s390x__)
+#define IEEE_8087 /* no idea why not IBM */
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define IEEE_8087
+#else
+#define IEEE_MC68k
+#endif
 
 /*
  * #define IEEE_8087 for IEEE-arithmetic machines where the least


### PR DESCRIPTION
This is a fix for #100: `extensions/dtoa.c` is system dependent and requires a switch between little and big endian. For some reason, although s390(x) (IBM zSeries) is big endian, it needs to be handled like little endian. Still, the ppc64 architecture (an unofficial Debian port) does not work.

It may be better to replace `extensions/dtoa.c` with the function [`PyOS_string_to_double()`](https://docs.python.org/2.7/c-api/conversion.html?highlight=strtod#c.PyOS_string_to_double), however a quick patch didn't make it for me.