### PR TITLE
Fix the microseconds returned by localtime

### DIFF
--- a/ephem/__init__.py
+++ b/ephem/__init__.py
@@ -516,7 +516,10 @@ def localtime(date):
     """Convert a PyEphem date into local time, returning a Python datetime."""
     import calendar, time, datetime
     timetuple = time.localtime(calendar.timegm(date.tuple()))
-    return datetime.datetime(*timetuple[:7])
+    timetuple = list(timetuple[:6])
+    microseconds = int(date.tuple()[5] * 1000000) % 1000000
+    timetuple.append(microseconds)
+    return datetime.datetime(*timetuple)
 
 # Coordinate transformations.
 

--- a/ephem/doc/date.rst
+++ b/ephem/doc/date.rst
@@ -61,9 +61,9 @@ and returns a Python ``datetime`` giving your local time.
 
     >>> lt = ephem.localtime(d)
     >>> print(lt)
-    1984-05-30 12:23:45.000002
+    1984-05-30 12:23:45.120000
     >>> print(repr(lt))
-    datetime.datetime(1984, 5, 30, 12, 23, 45, 2)
+    datetime.datetime(1984, 5, 30, 12, 23, 45, 120000)
 
 The output of this code will differ
 depending on the time zone in which you live.


### PR DESCRIPTION
There is a small bug in  [```localtime```](https://github.com/brandon-rhodes/pyephem/blob/026225ff566a858d6ef625c2bb2cb092ad20daa5/ephem/__init__.py#L518-L519):

```python
    timetuple = time.localtime(calendar.timegm(date.tuple()))
    return datetime.datetime(*timetuple[:7])
```

The bug is that [```timetuple[6]``` is the weekday](https://docs.python.org/2/library/time.html#time.struct_time), but [```datetime``` expects microseconds](https://docs.python.org/2/library/datetime.html#datetime.datetime). For the documentation's test date of 1984/05/30 (a Wednesday), the weekday value is 2. Hence the extra 2 microseconds in the output of ```localtime```:

```
>>> lt = ephem.localtime(d)
>>> print(lt)
1984-05-30 12:23:45.000002
>>> print(repr(lt))
datetime.datetime(1984, 5, 30, 12, 23, 45, 2)
```

This PR keeps ```localtime``` consistent with the original ```Date```'s microseconds:

```
>>> lt = ephem.localtime(d)
>>> print(lt)
1984-05-30 12:23:45.120000
>>> print(repr(lt))
datetime.datetime(1984, 5, 30, 12, 23, 45, 120000)
```