### PR TITLE
Fix Body_copy() to not corrupt PyObject_HEAD with a debug build of Python

### DIFF
--- a/extensions/_libastro.c
+++ b/extensions/_libastro.c
@@ -1332,10 +1332,13 @@ static PyObject* Body_writedb(PyObject *self)
 
 static PyObject* Body_copy(PyObject *self)
 {
+     Body *body = (Body *) self;
      Body *newbody = (Body*) self->ob_type->tp_alloc(self->ob_type, 0);
      if (!newbody) return 0;
-     memcpy(newbody, self, self->ob_type->tp_basicsize);
-     newbody->OB_REFCNT = 1;  /* since memcpy will have overwritten it */
+     memcpy ((void *)&newbody->now, (void *)&body->now, sizeof(Now));
+     memcpy ((void *)&newbody->obj, (void *)&body->obj, sizeof(Obj));
+     memcpy ((void *)&newbody->riset, (void *)&body->riset, sizeof(RiseSet));
+     newbody->name = body->name;
      Py_XINCREF(newbody->name);
      return (PyObject*) newbody;
 }


### PR DESCRIPTION
Python runs more checks when it is built with the [--with-pydebug
configure option](https://docs.python.org/3/c-api/intro.html#debugging-builds) and issues warnings or aborts when one of these checks fail. This is what happens in the following interactive session using a "debug build" of Python (here with the python development branch, but this should abort with 3.6 as well):

```
$ ./python
Python 3.8.0a0 (heads/master:c309bcfb9f, Feb  9 2018, 17:04:02)
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ephem
>>> ephem.star('Fomalhaut')
* ob
object  : <refcnt 0 at 0x7f941b206850>
type    : dict
refcount: 0
address : 0x7f941b206850
* op->_ob_prev->_ob_next
object  : 'Fomalhaut'
type    : str
refcount: 4
address : 0x7f941a8df5f0
* op->_ob_next->_ob_prev
object  : <refcnt 0 at 0x7f941b206850>
type    : dict
refcount: 0
address : 0x7f941b206850
Fatal Python error: UNREF invalid object

Current thread 0x00007f941c357040 (most recent call first):
  File "/path/to/ephem/__init__.py", line 679 in star
  File "<stdin>", line 1 in <module>
Aborted (core dumped)
```

In a debug build, Python uses a doubly-linked list of all live heap objects and the pointers of this list live in PyObject_HEAD of each object. The python function _Py_ForgetReference() in Objects/object.c checks that a PyObject about to be deallocated does not have a negative refcount and checks the sanity of this list and aborts here because the list is corrupted by Body_copy().

The PR fixes this problem. The whole pyephem test suite runs with success when the PR is applied.

