### PR TITLE
Consistently parse angles as the provided unit, regardless of type

### DIFF
--- a/extensions/_libastro.c
+++ b/extensions/_libastro.c
@@ -680,7 +680,7 @@ static double to_angle(PyObject *value, double efactor, int *status)
 	  r = PyFloat_AsDouble(value);
 	  Py_DECREF(value);
 	  *status = 0;
-	  return r;
+	  return r / efactor;
      } else if (PyUnicode_Check3(value)) {
 	  double scaled;
           char *s = PyUnicode_AsUTF8(value);


### PR DESCRIPTION
Currently, angles parsed by to_angle are assumed to be in radians if
specified as a number, and in the `efactor` unit if specified as a
string. This is inconsistent and confusing.

Fixes #157