### PR TITLE
Test with Python 3.9(-dev) on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 
 install:
   - pip install -e .


### PR DESCRIPTION
3.9.0 final or anything marked "3.9" is not there yet, but the -dev is a rolling version, currently apparently somewhere post 3.9.0.