### PR TITLE
Explicitly specify UTF-8 coding when opening files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if 'bdist_wheel' in sys.argv:
 # Read the current version from ephem/__init__.py itself.
 
 path = os.path.join(os.path.dirname(__file__), 'ephem', '__init__.py')
-for line in open(path):
+for line in open(path, encoding='utf8'):
     if line.startswith('__version__'):
         __version__ = eval(line.split(None, 2)[2]) # skip '__version__', '='
 
@@ -23,7 +23,7 @@ libastro_files = glob('libastro/*.c')
 libastro_data = glob('extensions/data/*.c')
 
 here = os.path.dirname(__file__)
-with open(os.path.join(here, 'README.rst')) as f:
+with open(os.path.join(here, 'README.rst'), encoding='utf8') as f:
     README = f.read()
 
 libraries = []


### PR DESCRIPTION
This PR explicitly specifies UTF-8 coding when opening files in setup.py in order to install this package on Windows with Asian languages installed.

Fixing this error:
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\AppData\Local\Temp\pip-instal3\ephem\setup.py", line 40, in <module>
        long_description = read('README.rst'),
      File "C:\Users\AppData\Local\Temp\pip-install\ephem\setup.py", line 27, in read
        return open(os.path.join(os.path.dirname(__file__), *filenames)).read()
    UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 4572: illegal multibyte sequence
```