### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(name = 'ephem',
       author = 'Brandon Rhodes',
       author_email = 'brandon@rhodesmill.org',
       url = 'http://rhodesmill.org/pyephem/',
+      project_urls = {
+          'Source': 'https://github.com/brandon-rhodes/pyephem',
+      },
       classifiers = [
         'Development Status :: 6 - Mature',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.