### PR TITLE
Changes for python 3.12

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_SKIP: pp*
           CIBW_TEST_COMMAND: python -m unittest discover ephem
@@ -32,7 +32,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -30,7 +30,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           #CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
           CIBW_ARCHS_LINUX: auto aarch64 s390x

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -46,9 +46,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -56,7 +56,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -64,7 +64,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/ephem/doc/date.rst
+++ b/ephem/doc/date.rst
@@ -114,7 +114,7 @@ Datetime objects
   You can also ask a PyEphem date to convert itself the other direction
   by calling its ``datetime()`` method.
 
-    >>> from datetime import date, datetime
+    >>> from datetime import date, datetime, timezone
     >>> print(ephem.Date(datetime(2005, 4, 18, 22, 15)))
     2005/4/18 22:15:00
 
@@ -138,7 +138,7 @@ Datetime objects
     >>> d = datetime.utcnow()
     >>> print(ephem.Date(d))
     2015/12/14 15:42:14
-    >>> d = datetime.utcfromtimestamp(1450107734)
+    >>> d = datetime.fromtimestamp(1450107734, tz=timezone.utc)
     >>> print(ephem.Date(d))
     2015/12/14 15:42:14
 

--- a/extensions/_libastro.c
+++ b/extensions/_libastro.c
@@ -3,6 +3,8 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
+#define PyUnicode_GetSize(o) PyUnicode_GET_SIZE(o)
+
 #if PY_MAJOR_VERSION == 2
 #define PyLong_AsLong PyInt_AsLong
 #define PyLong_FromLong PyInt_FromLong
@@ -23,6 +25,9 @@
 #define OB_REFCNT ob_base.ob_refcnt
 #if PY_MINOR_VERSION == 0 || PY_MINOR_VERSION == 1 || PY_MINOR_VERSION == 2
 #define PyUnicode_AsUTF8 _PyUnicode_AsString
+# elif PY_MINOR_VERSION >= 3
+#undef PyUnicode_GetSize
+#define PyUnicode_GetSize PyUnicode_GET_LENGTH
 #endif
 #endif
 
@@ -180,7 +185,7 @@ static int scansexa(PyObject *o, double *dp) {
                Py_DECREF(list);
                return -1;
           }
-          Py_ssize_t item_length = PyUnicode_GET_SIZE(item);
+          Py_ssize_t item_length = PyUnicode_GetSize(item);
           if (item_length == 0) {
                continue;  /* accept empty string for 0 */
           }


### PR DESCRIPTION
- Replace `PyUnicode_GET_SIZE` with `PyUnicode_GET_LENGTH` for Python `>=3.3`
https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_GET_SIZE
- Use `datetime.fromtimestamp` instead of `datetime.utcfromtimestamp` in the docs
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp
- Update `cibuildwheel` to `2.16.2` to build wheels for `3.12`
https://cibuildwheel.readthedocs.io/en/stable/changelog/#v2162