### PR TITLE
Update version to 4.1.5

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -7,11 +7,47 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            build: "*-manylinux_*"
+          - os: ubuntu-latest
+            arch: x86_64
+            build: "*-musllinux_*"
+          - os: ubuntu-latest
+            arch: i686
+            build: "*-manylinux_*"
+          - os: ubuntu-latest
+            arch: i686
+            build: "*-musllinux_*"
+
+          - os: ubuntu-latest
+            arch: aarch64
+            build: "*-manylinux_*"
+          - os: ubuntu-latest
+            arch: aarch64
+            build: "*-musllinux_*"
+          - os: ubuntu-latest
+            arch: s390x
+            build: "*-manylinux_*"
+          - os: ubuntu-latest
+            arch: s390x
+            build: "*-musllinux_*"
+
+          - os: windows-latest
+            arch: AMD64
+          - os: windows-latest
+            arch: x86
+
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -32,11 +68,12 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          #CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
-          CIBW_ARCHS_LINUX: auto aarch64 s390x
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.build }}
           CIBW_SKIP: pp*
           CIBW_TEST_COMMAND: python -m unittest discover ephem
           CIBW_TEST_REQUIRES: tzdata
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/ephem/__init__.py
+++ b/ephem/__init__.py
@@ -10,7 +10,7 @@ from datetime import tzinfo as _tzinfo
 from math import acos, cos, isnan, pi, sin
 from time import localtime as _localtime
 
-__version__ = '4.1.4'
+__version__ = '4.1.5'
 
 # As a favor, compile a regular expression that our C library would
 # really rather not compile for itself.

--- a/ephem/doc/CHANGELOG.rst
+++ b/ephem/doc/CHANGELOG.rst
@@ -2,6 +2,12 @@
 PyEphem CHANGELOG
 =================
 
+Version 4.1.5 (2023 October 8)
+------------------------------
+
+- Add support for Python 3.12.
+  `#259 <https://github.com/brandon-rhodes/pyephem/pull/259>`_
+
 Version 4.1.4 (2022 December 21)
 --------------------------------
 


### PR DESCRIPTION
- Update version to `4.1.5`
- Add changelog entry
- Split up wheel builder matrix for faster builds
- Build wheels for MacOS `arm64`

Ref:
- https://github.com/brandon-rhodes/pyephem/issues/261#issuecomment-1751935346