### PR TITLE
Updates XEphem links to use new Github pages url.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,7 +10,7 @@ astronomical computations.  You can find the most recent version at
 
 The computation routines behind PyEphem are from the "XEphem" program
 by Elwood Charles Downey (ecdowney@ClearSkyInstitute.com), available
-from http://www.clearskyinstitute.com/xephem/.  See the COPYING file
+from https://xephem.github.io/XEphem/Site/xephem.  See the COPYING file
 in this directory for licensing information.
 
 INSTALLING

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ PyEphem README
 
 .. _ephem: http://pypi.python.org/pypi/ephem/
 .. _pyephem: http://pypi.python.org/pypi/pyephem/
-.. _XEphem: http://www.clearskyinstitute.com/xephem/
+.. _XEphem: https://xephem.github.io/XEphem/Site/xephem
 .. _Quick Reference: http://rhodesmill.org/pyephem/quick
 .. _Tutorial: http://rhodesmill.org/pyephem/tutorial
 .. _PyEphem web site: http://rhodesmill.org/pyephem/

--- a/ephem/doc/index.rst
+++ b/ephem/doc/index.rst
@@ -130,7 +130,7 @@ But be warned that it has some rough edges!
   but users needing higher precision should investigate
   a more modern Python astronomy library like Skyfield or AstroPy.
 
-.. _XEphem: http://www.clearskyinstitute.com/xephem/
+.. _XEphem: https://xephem.github.io/XEphem/Site/xephem
 
 Here’s more example code to illustrate how PyEphem works:
 

--- a/ephem/doc/radec.rst
+++ b/ephem/doc/radec.rst
@@ -2,7 +2,7 @@
 Right Ascension and Declination
 ===============================
 
-.. _XEphem: http://www.clearskyinstitute.com/xephem/
+.. _XEphem: https://xephem.github.io/XEphem/Site/xephem
 
 There are several different ways
 of specifying the position of an object


### PR DESCRIPTION
Small fixes. Thanks for the great work. This project is very awesome.

Changes `http://www.clearskyinstitute.com/xephem/` to `https://xephem.github.io/XEphem/Site/xephem`.

\- Tom